### PR TITLE
[makefile] List correct dependencies of `sqlines` binary

### DIFF
--- a/sqlines/makefile
+++ b/sqlines/makefile
@@ -1,2 +1,14 @@
-sqlines:
-	g++ $(CXXFLAGS) applog.cpp file.cpp filelist.cpp main.cpp os.cpp parameters.cpp sqlines.cpp str.cpp ../sqlparser/sqlparser.a -o sqlines
+SRC = \
+  applog.cpp \
+  file.cpp \
+  filelist.cpp \
+  main.cpp \
+  os.cpp \
+  parameters.cpp \
+  sqlines.cpp \
+  str.cpp
+
+LIBS = ../sqlparser/sqlparser.a
+
+sqlines: $(SRC) $(LIBS)
+	g++ $(CXXFLAGS) $(SRC) $(LIBS) -o $@


### PR DESCRIPTION
Avoids the annoying "nothing to do" message when sqlparser
library (or any source code) changes